### PR TITLE
修改，当链表中仅有1个节点时错误

### DIFF
--- a/docs/剑指offer/Java/18_01_DeleteNodeInList/README.md
+++ b/docs/剑指offer/Java/18_01_DeleteNodeInList/README.md
@@ -24,23 +24,30 @@ public class Solution {
      * @param head 链表头节点
      * @param tobeDelete 要删除的节点
      */
-    public void deleteNode(ListNode head, ListNode tobeDelete) {
+    public ListNode deleteNode(ListNode head, ListNode tobeDelete) {
         if (head == null || tobeDelete == null) {
-            return;
+            return head;
         }
 
-        // 说明要删除的是最后一个节点
-        if (tobeDelete.next == null) {
+        // 删除的不是尾节点
+        if (tobeDelete.next != null) {
+            tobeDelete.val = tobeDelete.next.val;
+            tobeDelete.next = tobeDelete.next.next;
+        }
+        // 链表中仅有一个节点
+        else if (head == tobeDelete) {
+            head = null;
+        }
+        // 删除的是尾节点
+        else {
             ListNode cur = head;
             while (cur.next != tobeDelete) {
                 cur = cur.next;
             }
             cur.next = null;
-        } else {
-            // 非尾节点，直接把该节点的下一个节点赋给当前节点
-            tobeDelete.val = tobeDelete.next.val;
-            tobeDelete.next = tobeDelete.next.next;
         }
+
+        return head;
     }
 }
 ```

--- a/docs/剑指offer/Java/18_01_DeleteNodeInList/Solution.java
+++ b/docs/剑指offer/Java/18_01_DeleteNodeInList/Solution.java
@@ -16,22 +16,29 @@ public class Solution {
      * @param head       链表头节点
      * @param tobeDelete 要删除的节点
      */
-    public void deleteNode(ListNode head, ListNode tobeDelete) {
+    public ListNode deleteNode(ListNode head, ListNode tobeDelete) {
         if (head == null || tobeDelete == null) {
-            return;
+            return head;
         }
 
-        // 说明要删除的是最后一个节点
-        if (tobeDelete.next == null) {
+        // 删除的不是尾节点
+        if (tobeDelete.next != null) {
+            tobeDelete.val = tobeDelete.next.val;
+            tobeDelete.next = tobeDelete.next.next;
+        }
+        // 链表中仅有一个节点
+        else if (head == tobeDelete) {
+            head = null;
+        }
+        // 删除的是尾节点
+        else {
             ListNode cur = head;
             while (cur.next != tobeDelete) {
                 cur = cur.next;
             }
             cur.next = null;
-        } else {
-            // 非尾节点，直接把该节点的下一个节点赋给当前节点
-            tobeDelete.val = tobeDelete.next.val;
-            tobeDelete.next = tobeDelete.next.next;
         }
+
+        return head;
     }
 }


### PR DESCRIPTION
当测试用例链表中仅有1个节点时，该代码会报空指针异常，增加判断逻辑并返回被删除后的链表