### PR TITLE
 improve the time complexity from O(n^2) to O(n)

### DIFF
--- a/docs/剑指offer/Java/56_01_NumbersAppearOnce/README.md
+++ b/docs/剑指offer/Java/56_01_NumbersAppearOnce/README.md
@@ -66,9 +66,7 @@ class Solution {
     }
 
     private boolean isBit1(int val, int index) {
-        for (int i = 0; i < index; ++i) {
-            val = val >> 1;
-        }
+        val = val >> index;
         return (val & 1) == 1;
     }
 }

--- a/docs/剑指offer/Java/56_01_NumbersAppearOnce/Solution.java
+++ b/docs/剑指offer/Java/56_01_NumbersAppearOnce/Solution.java
@@ -41,9 +41,7 @@ class Solution {
     }
 
     private boolean isBit1(int val, int index) {
-        for (int i = 0; i < index; ++i) {
-            val = val >> 1;
-        }
+        val = val >> index;
         return (val & 1) == 1;
     }
 }


### PR DESCRIPTION
method1 and method2 can get same answer , but the time complexity of method2 is O(n) while method1 is O(n^2)
```java
   // method1
    private boolean isBit1(int val, int index) {
        for (int i = 0; i < index; ++i) {
            val = val >> 1;
        }
        return (val & 1) == 1;
    }
   // method2
    private boolean isBit1(int val, int index) {
        val = val >> index;
        return (val & 1) == 1;
    }
```
