### PR TITLE
update wrong solution of 5801

### DIFF
--- a/docs/剑指offer/Java/58_01_ReverseWordsInSentence/README.md
+++ b/docs/剑指offer/Java/58_01_ReverseWordsInSentence/README.md
@@ -31,7 +31,7 @@ class Solution {
      * @return 翻转后的字符串
      */
     public String reverseWords(String s) {
-        if (s == null || s.length() < 2) {
+        if (s == null || s.length() == 0 || s.trim().equals("")) {
             return s;
         }
 

--- a/docs/剑指offer/Java/58_01_ReverseWordsInSentence/Solution.java
+++ b/docs/剑指offer/Java/58_01_ReverseWordsInSentence/Solution.java
@@ -11,7 +11,7 @@ class Solution {
      * @return 翻转后的字符串
      */
     public String reverseWords(String s) {
-        if (s == null || s.length() < 2) {
+        if (s == null || s.length() == 0 || s.trim().equals("")) {
             return s;
         }
 


### PR DESCRIPTION
When input string is 
```
"    "
```
The string is only composed of the spaces and spaces are more than one  , the answer is wrong . Adding `s.trim().equals("")`  to avoid it , such as
```java
if (s == null || s.length() == 0 || s.trim().equals("")) {
    return s;
}

```
