### PR TITLE
fix errors in 18_01_DeleteNodeInList

### DIFF
--- a/docs/剑指offer/Java/18_01_DeleteNodeInList/README.md
+++ b/docs/剑指offer/Java/18_01_DeleteNodeInList/README.md
@@ -43,7 +43,7 @@ public class Solution {
         // 删除的是尾节点
         else {
             ListNode ptr = head;
-            while (ptr.next != tobeDeleted) {
+            while (ptr.next != tobeDelete) {
                 ptr = ptr.next;	
           	}
             ptr.next = null;

--- a/docs/剑指offer/Java/18_01_DeleteNodeInList/README.md
+++ b/docs/剑指offer/Java/18_01_DeleteNodeInList/README.md
@@ -42,8 +42,11 @@ public class Solution {
         }
         // 删除的是尾节点
         else {
-            // 当head遍历到tobeDelete时，指向的是同一个引用。可以直接将tobeDelete = null即可
-            tobeDelete = null;
+            ListNode ptr = head;
+            while (ptr.next != tobeDeleted) {
+                ptr = ptr.next;	
+          	}
+            ptr.next = null;
         }
 
         return head;

--- a/docs/剑指offer/Java/18_01_DeleteNodeInList/Solution.java
+++ b/docs/剑指offer/Java/18_01_DeleteNodeInList/Solution.java
@@ -32,8 +32,11 @@ public class Solution {
         }
         // 删除的是尾节点
         else {
-            // 当head遍历到tobeDelete时，指向的是同一个引用。可以直接将tobeDelete = null即可
-            tobeDelete = null;
+            ListNode ptr = head;
+            while (ptr.next != tobeDelete) {
+            	ptr = ptr.next;
+            }
+            ptr.next = null;
         }
 
         return head;


### PR DESCRIPTION
> // 当head遍历到tobeDelete时，指向的是同一个引用。可以直接将tobeDelete = null即可

有误。 `tobeDelete = null`只会将该方法作用域中的tobeDelete指向null，并不会删除尾节点。

<img width="1306" alt="屏幕快照 2019-03-20 14 34 00" src="https://user-images.githubusercontent.com/17743757/54664677-e506ac80-4b1f-11e9-8383-706c303f08c0.png">


